### PR TITLE
Fix CAPI pivot and restructure cluster naming and locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is not a complete production-ready pattern rather iterative approach to get
 Deviations from the quick starts are improvements around least privilege principle, preference to "as Code" approach opposed to cli commands, cost-optimization, etc.
 
 Flux repositories structure follows ["Repo per team"](https://fluxcd.io/docs/guides/repository-structure/#repo-per-team) approach.
-Cluster API deployment follows ["Boostrap & Pivot"](https://cluster-api.sigs.k8s.io/clusterctl/commands/move.html) approach with initial temporary management cluster running on `kind`. At the moment it is not entirely clear to me how to manage the permanent management cluster.
+Cluster API deployment follows ["Boostrap & Pivot"](https://cluster-api.sigs.k8s.io/clusterctl/commands/move.html) approach with initial temporary management cluster running on `kind`.
 
 My previous experiment with permanent management cluster bootstraped by kOps with workload cluster applied by FluxCD: https://github.com/olga-mir/k8s/releases/tag/v0.0.1
 

--- a/clusters/cluster-dev/flux-system/gotk-sync.yaml
+++ b/clusters/cluster-dev/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: feature/kubefed-and-kong
+    branch: feature/cluster-management
   secretRef:
     name: flux-system
   url: ssh://git@github.com/olga-mir/k8s-multi-cluster

--- a/clusters/mgmt/flux-system/gotk-sync.yaml
+++ b/clusters/mgmt/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: feature/kubefed-and-kong
+    branch: feature/cluster-management
   secretRef:
     name: flux-system
   url: ssh://git@github.com/olga-mir/k8s-multi-cluster

--- a/mgmt-cluster/cluster.yaml
+++ b/mgmt-cluster/cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: mgmt
-  namespace: default
+  namespace: cluster-mgmt
   labels:
     cluster.x-k8s.io/cluster-name: mgmt
     cni: calico
@@ -24,7 +24,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:
   name: mgmt
-  namespace: default
+  namespace: cluster-mgmt
 spec:
   region: ap-southeast-2
   sshKeyName: cks
@@ -36,7 +36,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
   name: mgmt-control-plane
-  namespace: default
+  namespace: cluster-mgmt
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
@@ -68,7 +68,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: mgmt-control-plane
-  namespace: default
+  namespace: cluster-mgmt
 spec:
   template:
     spec:
@@ -80,7 +80,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: mgmt-md-0
-  namespace: default
+  namespace: cluster-mgmt
 spec:
   clusterName: mgmt
   replicas: 1
@@ -104,7 +104,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: mgmt-md-0
-  namespace: default
+  namespace: cluster-mgmt
 spec:
   template:
     spec:
@@ -116,7 +116,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: mgmt-md-0
-  namespace: default
+  namespace: cluster-mgmt
 spec:
   template:
     spec:
@@ -131,7 +131,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
  name: crs-calico
- namespace: default
+ namespace: cluster-mgmt
 spec:
  strategy: 'ApplyOnce'
  clusterSelector:

--- a/scripts/brutal-aws-cleanup.sh
+++ b/scripts/brutal-aws-cleanup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+exit 1
+
+# Quick delete all resources that make up the clusters provisioned in this account. (did I say it is brutal)
+# CAPI delete hangs for too long on deleting VPC even though the VPC can be released if tried manually via console.
+
+set -eoux pipefail
+
+running_instances=$(aws ec2 describe-instances --filters "Name=instance-state-name,Values=running" --query "Reservations[].Instances[].InstanceId" --output=text)
+aws ec2 terminate-instances --instance-ids $running_instances
+
+nat_gateways=$(aws ec2 describe-nat-gateways --query "NatGateways[].NatGatewayId")
+for n in ${nat_gateways[@]}; do
+  aws ec2 delete-nat-gateway --nat-gateway-id $n
+done
+
+aws elb delete-load-balancer --load-balancer-name=mgmt-apiserver
+sleep 60
+
+aws ec2 release-address --allocation-id=$(aws ec2 describe-addresses --query "Addresses[].AllocationId" --output=text)
+
+# Some time after NAT and LB are deleted and ENIs are deleted it will be possible to simply delete VPC from the console.
+# The command will still hang though, if attempted to delete from CLI:
+# $ aws ec2 delete-vpc --vpc-id vpc-<my-vpc-id>
+# An error occurred (DependencyViolation) when calling the DeleteVpc operation: The vpc 'vpc-0158ac36bf386c091' has dependencies and cannot be deleted.
+# (This is the same error as seen in the CAPA logs in `k get events -n <cluster-ns>`
+# In AWS console SGs, IGW, subnets and other dependencies are listed as a warning only, not a blocker.
+# They are deleted as part of VPC deletion.
+# There is no flag on the CLI that can provide the same behaviour.
+
+# List of resources that were left in VPC after running this script
+#    sg- / mgmt-bastion
+#    sg- / mgmt-apiserver-lb
+#    sg- / mgmt-lb
+#    sg- / mgmt-node
+#    sg- / mgmt-controlplane
+#    igw- / mgmt-igw
+#    subnet- / mgmt-subnet-public-ap-southeast-2a
+#    subnet- / mgmt-subnet-private-ap-southeast-2a
+#    rtb- / mgmt-rt-private-ap-southeast-2a
+#    rtb- / mgmt-rt-public-ap-southeast-2a

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -4,6 +4,10 @@ workdir=$(pwd)
 
 # This script assumes it runs on the same setup as deployed by other scripts in this repo.
 # The following contexts are expected to be available in kubeconfig (use ./scripts/merge-kubeconfig.sh) to merge all in one
+# CURRENT   NAME            CLUSTER     AUTHINFO     NAMESPACE
+# *         dev             dev         dev-admin
+#           kind-kind       kind-kind   kind-kind
+#           mgmt            mgmt        mgmt-admin
 
 if [[ -z "$ACCEPT_CLEANUP_T_AND_C" ]]; then
   echo "ERROR"
@@ -19,13 +23,24 @@ echo Suspend CAPI sources reconciliation.
 flux suspend kustomization infrastructure
 
 echo $(date '+%F %H:%M:%S')
-kubectl delete cluster dev -n cluster-dev
-
-echo $(date '+%F %H:%M:%S')
-#clusterctl move --kubeconfig=$workdir/target-mgmt.kubeconfig --kubeconfig-context mgmt-admin@mgmt --to-kubeconfig=$HOME/.kube/config --to-kubeconfig-context=kind-kind
-clusterctl move --to-kubeconfig=$HOME/.kube/config --to-kubeconfig-context=kind-kind
+clusterctl move --to-kubeconfig=$HOME/.kube/config --to-kubeconfig-context=kind-kind -n cluster-dev
+clusterctl move --to-kubeconfig=$HOME/.kube/config --to-kubeconfig-context=kind-kind -n cluster-mgmt
 
 echo "---- Switching to 'kind' cluster"
 kubectl config use-context kind-kind
-# TODO - test: move both clusters to `kind` and delete in parallel
-# kubectl delete cluster mgmt -n cluster-mgmt
+kubectl delete cluster mgmt -n cluster-mgmt &
+kubectl delete cluster dev -n cluster-dev &
+
+echo $(date '+%F %H:%M:%S')
+sleep 600
+
+while kubectl get cluster mgmt -n cluster-mgmt; do
+  sleep 60
+done
+
+echo $(date '+%F %H:%M:%S')
+while kubectl get cluster dev -n cluster-dev; do
+  sleep 30
+done
+
+kind delete cluster

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -33,4 +33,4 @@ clusterctl move --to-kubeconfig=$HOME/.kube/config --to-kubeconfig-context=kind-
 
 echo "---- Switching to 'kind' cluster"
 kubectl config use-context kind-kind
-kubectl delete cluster mgmt -n default
+kubectl delete cluster mgmt -n cluster-mgmt

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -5,12 +5,6 @@ workdir=$(pwd)
 # This script assumes it runs on the same setup as deployed by other scripts in this repo.
 # The following contexts are expected to be available in kubeconfig (use ./scripts/merge-kubeconfig.sh) to merge all in one
 
-# % k config get-contexts
-# CURRENT   NAME              CLUSTER     AUTHINFO     NAMESPACE
-#           dev-admin@dev     dev         dev-admin
-#           kind-kind         kind-kind   kind-kind
-# *         mgmt-admin@mgmt   mgmt        mgmt-admin
-
 if [[ -z "$ACCEPT_CLEANUP_T_AND_C" ]]; then
   echo "ERROR"
   echo "ERROR  Please make sure you understand what is being deleted by this script."
@@ -19,7 +13,7 @@ if [[ -z "$ACCEPT_CLEANUP_T_AND_C" ]]; then
 fi
 
 echo "---- Switching to mgmt cluster"
-kubectl config use-context mgmt-admin@mgmt
+kubectl config use-context mgmt
 
 echo Suspend CAPI sources reconciliation.
 flux suspend kustomization infrastructure
@@ -33,4 +27,5 @@ clusterctl move --to-kubeconfig=$HOME/.kube/config --to-kubeconfig-context=kind-
 
 echo "---- Switching to 'kind' cluster"
 kubectl config use-context kind-kind
-kubectl delete cluster mgmt -n cluster-mgmt
+# TODO - test: move both clusters to `kind` and delete in parallel
+# kubectl delete cluster mgmt -n cluster-mgmt

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,7 +6,10 @@ set -eou pipefail
 # Provide env vars and other settings in $workdir/mgmt-cluster/init-config-mgmt.yaml file
 # (note that the content of the file is not validated)
 # AWS_B64ENCODED_CREDENTIALS currently accepted only from env var only.
-if [ -z "$AWS_B64ENCODED_CREDENTIALS" ]; then
+if [ -z "$AWS_B64ENCODED_CREDENTIALS" ] && \
+   [ -z "$FLUX_REPO_SSH" ] && \   # ssh format for 'this' repo, e.g. ssh://git@github.com/olga-mir/k8s-multi-cluster
+   [ -z "$FLUX_BRANCH" ] && \     # branch in this repo for flux to sync
+   [ -z "$FLUX_KEY_PATH" ]; then  # path to ssh key which is a deployment key for this repo
   echo "Error AWS_B64ENCODED_CREDENTIALS is not provided" && exit 1
 fi
 
@@ -32,9 +35,8 @@ set +e
 while ! kubectl wait crd clusters.cluster.x-k8s.io --for=condition=Established --timeout=5s; do sleep 15; done
 set -e
 
-# deploy permanent mgmt cluster object in `default` ns in temp cluster
-# use manifests that were created before with `clusterctl generate cluster mgmt`
-# and committed to the repo
+# deploy permanent mgmt cluster object using
+# manifests that were created beforehand with `clusterctl generate cluster mgmt`
 
 # applying cluster manifests immediatelly will fail because components webhooks are not yet ready to serve traffic
 # it is easier to retry applying rather than checking on each component individually
@@ -59,7 +61,7 @@ set -e
 kubectl apply -f $workdir/mgmt-cluster/cm-calico-v3.21.yaml
 
 echo $(date '+%F %H:%M:%S')
-sleep 90
+sleep 120
 while ! kubectl wait --for condition=ResourcesApplied=True clusterresourceset crs-calico --timeout=30s ; do
   echo $(date '+%F %H:%M:%S') waiting for management cluster to become ready
 done
@@ -69,18 +71,15 @@ done
 
 # kubeconfig is available when this secret is ready: `k get secret mgmt-kubeconfig`
 clusterctl get kubeconfig mgmt > $workdir/target-mgmt.kubeconfig
-clusterctl init --infrastructure aws --kubeconfig $workdir/target-mgmt.kubeconfig --kubeconfig-context mgmt-admin@mgmt --config $workdir/mgmt-cluster/init-config-workload.yaml
+# Apart from being shorter and nicer, it is also required later for kubefed which breaks when there are special chars in context name
+kubectl config rename-context mgmt-admin@mgmt mgmt
+
+clusterctl init --infrastructure aws --kubeconfig $workdir/target-mgmt.kubeconfig --kubeconfig-context mgmt --config $workdir/mgmt-cluster/init-config-workload.yaml
 
 echo $(date '+%F %H:%M:%S')
 set +e
-# this is confusing wait. At this stage we don't expect to see clusters in the mgmt cluster
-# this is only checking that clusters *can* be created, i.e. that clusterctl init worked.
-# there should be better check
-while ! kubectl --kubeconfig=$workdir/target-mgmt.kubeconfig get clusters; do
-  sleep 15
-done
+while ! kubectl --kubeconfig=$workdir/target-mgmt.kubeconfig wait crd clusters.cluster.x-k8s.io --for=condition=Established; do sleep 15; done
 set -e
-echo \"No resources found in default namespace\" expected
 
 clusterctl move --to-kubeconfig=./target-mgmt.kubeconfig
 
@@ -109,10 +108,10 @@ clusterctl move --to-kubeconfig=./target-mgmt.kubeconfig
 # `k get secret flux-system -n flux-system` is the secret in the link above (ssh-credentials)
 
 flux bootstrap git \
-  --kubeconfig=$workdir/target-mgmt.kubeconfig --context mgmt-admin@mgmt \
-  --url=ssh://git@github.com/olga-mir/k8s-multi-cluster \
-  --branch=feature/kubefed-and-kong \
-  --private-key-file=$HOME/.ssh/flux-github-key \
+  --kubeconfig=$workdir/target-mgmt.kubeconfig --context mgmt \
+  --url=$FLUX_REPO_SSH \
+  --branch=$FLUX_BRANCH \
+  --private-key-file=$FLUX_KEY_PATH \
   --path=clusters/mgmt
 
 
@@ -120,16 +119,17 @@ flux bootstrap git \
 
 # Once Flux is bootstrapped on the cluster it will apply cluster-dev CAPI definition and workload cluster will start provisioning
 sleep 90
-while ! kubectl --kubeconfig=$workdir/target-mgmt.kubeconfig wait --context mgmt-admin@mgmt --for condition=ResourcesApplied=True clusterresourceset crs-calico -n cluster-dev --timeout=15s ; do
+while ! kubectl --kubeconfig=$workdir/target-mgmt.kubeconfig wait --context mgmt --for condition=ResourcesApplied=True clusterresourceset crs-calico -n cluster-dev --timeout=15s ; do
   echo $(date '+%F %H:%M:%S') waiting for workload cluster to become ready
   sleep 15
 done
 
-clusterctl --kubeconfig=$workdir/target-mgmt.kubeconfig --kubeconfig-context mgmt-admin@mgmt get kubeconfig dev -n cluster-dev > $workdir/dev.kubeconfig
+clusterctl --kubeconfig=$workdir/target-mgmt.kubeconfig --kubeconfig-context mgmt get kubeconfig dev -n cluster-dev > $workdir/dev.kubeconfig
+kubectl config rename-context dev-admin@dev dev
 
 flux bootstrap git \
-  --kubeconfig=$workdir/dev.kubeconfig --context dev-admin@dev \
-  --url=ssh://git@github.com/olga-mir/k8s-multi-cluster \
-  --branch=feature/kubefed-and-kong \
-  --private-key-file=$HOME/.ssh/flux-github-key \
+  --kubeconfig=$workdir/dev.kubeconfig --context dev \
+  --url=$FLUX_REPO_SSH \
+  --branch=$FLUX_BRANCH \
+  --private-key-file=$FLUX_KEY_PATH \
   --path=clusters/cluster-dev

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -82,7 +82,7 @@ set +e
 while ! kubectl --kubeconfig=$workdir/target-mgmt.kubeconfig wait crd clusters.cluster.x-k8s.io --for=condition=Established; do sleep 15; done
 set -e
 
-clusterctl move --to-kubeconfig=./target-mgmt.kubeconfig
+clusterctl move --to-kubeconfig=./target-mgmt.kubeconfig -n cluster-mgmt
 
 # Now `mgmt` cluster lives on the AWS permanent management cluster:
 # % k get clusters -A

--- a/tenants/base/team-1/sync.yaml
+++ b/tenants/base/team-1/sync.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1m
   url:  ssh://git@github.com/olga-mir/my-app
   ref:
-    branch: team-1
+    branch: main
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization


### PR DESCRIPTION
In previous version there was a bug where clusterctl move was moving from empty cluster rather than from the temp `kind` cluster. This PR fixes it and improves cleanup too now that the cluster move is understood :D 
Also I now know why dev cluster deletion is stuck and why it was easy to release from AWS console by manually deleting the VPC. This was happening because of kong security group - CAPI does not own it, so it rightfully doesn't remove it. Need to implement `kong` uninstall.  